### PR TITLE
add template file for api-ref page

### DIFF
--- a/docs/assets/files/grpc-api-ref-md.tmpl
+++ b/docs/assets/files/grpc-api-ref-md.tmpl
@@ -1,0 +1,70 @@
+# API Reference
+
+# Table of Contents
+{{range .Files}}
+## {{.Name}}
+
+{{if .HasServices}}
+- Services
+  {{range .Services}}  - [{{.Name}}](#{{.FullName | lower | replace "." ""}})
+  {{end}}
+{{end}}
+{{if .HasMessages}}
+- Messages
+  {{range .Messages}}  - [{{.LongName}}](#{{.LongName | lower | replace "." ""}})
+  {{end}}
+{{end}}
+{{if .HasEnums}}
+- Enums
+  {{range .Enums}}  - [{{.LongName}}](#{{.LongName | lower | replace "." ""}})
+  {{end}}
+{{end}}
+{{end}}
+
+{{range .Files}}
+
+{{range .Services -}}
+# {{.Name}} {#{{.FullName | lower | replace "." ""}}}
+{{.Description}}
+
+{{range .Methods -}}
+## {{.Name}}
+
+> **rpc** {{.Name}}([{{.RequestLongType}}](#{{.RequestLongType | lower | replace "." ""}}))
+    returns [{{.ResponseLongType}}](#{{.ResponseLongType | lower | replace "." ""}})
+
+{{ .Description}}
+{{end}}
+{{end}}
+
+# Messages
+{{range .Messages}}
+
+## {{.LongName}} {#{{.LongName | lower | replace "." ""}}}
+{{.Description}}
+
+{{if .HasFields}}
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+{{range .Fields -}}
+	| {{if .IsOneof}}[**oneof**](https://developers.google.com/protocol-buffers/docs/proto3#oneof) {{.OneofDecl}}.{{end}}{{.Name}} | [{{if .IsMap}}map {{else}}{{.Label}} {{end}}{{.LongType}}](#{{.LongType | lower | replace "." ""}}) | {{if .Description}}{{nobr .Description}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}}{{else}}none{{end}} |
+{{end}}
+{{end}}
+{{end}}
+
+{{if .HasEnums}}
+# Enums
+{{range .Enums}}
+
+## {{.LongName}} {#{{.LongName | lower | replace "." ""}}}
+{{.Description}}
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+{{range .Values -}}
+	| {{.Name}} | {{.Number}} | {{if .Description}}{{nobr .Description}}{{else}}none{{end}} |
+{{end}}
+
+{{end}}
+{{end}}
+{{end}}


### PR DESCRIPTION
API reference page 렌더링 시에 사용한 템플릿 파일 asset 디렉토리에 추가합니다. 
같이 관리하지 않으면 나중에 유실될거 같아서요.