### PR TITLE
Fix releasenotes

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,7 +66,9 @@ markdown_extensions:
 nav:
   - Welcome: index.md
   - Quick Start: quickstart/1-0-0.md
-  - Release Note: releasenotes/1-0-0.md
+  - Release Note:
+      - 'v2.0.0': releasenotes/1-0-0.md
+      - 'v1.0.0': releasenotes/1-0-0.md
   - Architecture: 
       - 'Overview': architecture/overviewarch.md
       - 'GitOps Architecture': architecture/tksgitops.md


### PR DESCRIPTION
기존에 1.0.0으로 릴리즈노트가 작성되어있는데, 일단 새로 따는 릴리즈 버전은 2.0.0이기 때문에 1.0.0과 2.0.0을 따로 볼수 있도록 추가했습니다.

그러나 2.0.0문서도 1.0.0을 바라보도록 되어있습니다. (실제 내용이 변경된것은 없기에)

1.0.0 문서를 삭제해야할까요?